### PR TITLE
Fix reserved word usage in QML parameter delegates

### DIFF
--- a/app/ui_qt/parameter_bridge.py
+++ b/app/ui_qt/parameter_bridge.py
@@ -99,7 +99,7 @@ class ParameterListModel(QtCore.QAbstractListModel):
             self.LabelRole: b"label",
             self.TypeRole: b"type",
             self.ValueRole: b"value",
-            self.DefaultRole: b"default",
+            self.DefaultRole: b"defaultValue",
             self.UnitRole: b"unit",
             self.CategoryRole: b"category",
             self.AdvancedRole: b"advanced",

--- a/app/ui_qt/qml/Main.qml
+++ b/app/ui_qt/qml/Main.qml
@@ -293,7 +293,7 @@ ApplicationWindow {
 
                 Label {
                     anchors.centerIn: parent
-                    text: qsTr("Override: %1 (default %2)").arg(value).arg(default)
+                    text: qsTr("Override: %1 (default %2)").arg(value).arg(defaultValue)
                     font.pixelSize: 11
                 }
             }
@@ -354,7 +354,7 @@ ApplicationWindow {
                         text = String(parsed)
                     }
                 }
-                Label { text: qsTr("default %1").arg(default) }
+                Label { text: qsTr("default %1").arg(defaultValue) }
             }
 
             Slider {
@@ -389,7 +389,7 @@ ApplicationWindow {
             }
 
             Label {
-                text: qsTr("default %1").arg(default)
+                text: qsTr("default %1").arg(defaultValue)
                 color: "#777"
             }
         }


### PR DESCRIPTION
## Summary
- expose the parameter default value to QML using a non-reserved role name
- update the parameter editor delegates to reference the renamed default value role

## Testing
- python -m compileall app/ui_qt/parameter_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68da0a4156308333bdf417844ac4eed2