### PR TITLE
Factor out PyBaMM export helpers and add coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,22 @@ library exposes a minimal C interface that the Python UI consumes via `ctypes`.
 ## Running the Qt UI
 
 The Qt desktop shell is implemented in Python using PySide6. Install the runtime dependencies and
-launch the shell after building the C++ core so that the shared library is available:
+launch the shell after building the C++ core so that the shared library is available. The parameter
+explorer now introspects the active PyBaMM installation to expose the entire parameter catalogue and
+can execute a full PyBaMM simulation with MDF/DAT exports when the optional Python packages are
+installed:
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install PySide6
+pip install PySide6 pybamm asammdf
 python app/ui_qt/main.py
 ```
 
-Click **Run default scenario** to execute the built-in battery pack discharge scenario via the
-C++ orchestrator.
+Click **Run default scenario** to run the PyBaMM DFN model with the current overrides and export the
+results as `.dat` and `.mdf` files inside `data/simulations`. If `asammdf` is not available the MDF
+export is skipped and the UI reports the missing optional dependency alongside the success message.
+The button also retains the legacy link to the C++ orchestrator when the shared library is present.
 
 ## WLTP single-cell export
 

--- a/app/ui_qt/pybamm_runner.py
+++ b/app/ui_qt/pybamm_runner.py
@@ -1,0 +1,190 @@
+"""Utilities for executing PyBaMM simulations and exporting their results.
+
+This module centralises the glue that the Qt layer relies on so that it can
+be reused by command-line tooling or automated tests without having to reach
+into the ``ParameterBridge`` implementation details. The helpers purposely
+avoid importing PySide to keep their dependency surface minimal.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence
+
+
+# A curated set of variables that provide a representative snapshot of the
+# single-cell behaviour. Additional variables can be requested by callers via
+# ``extra_variables`` when executing a simulation.
+DEFAULT_EXPORT_VARIABLES: Sequence[str] = (
+    "Terminal voltage [V]",
+    "Voltage [V]",
+    "Current [A]",
+    "Discharge capacity [A.h]",
+    "Cell temperature [K]",
+    "X-averaged cell temperature [K]",
+)
+
+
+@dataclass
+class ExportResult:
+    """Metadata about the artefacts written by :func:`export_simulation_results`."""
+
+    dat_path: pathlib.Path
+    mdf_path: Optional[pathlib.Path]
+    warnings: List[str] = field(default_factory=list)
+
+
+def run_pybamm_simulation(
+    *,
+    chemistry: str,
+    model: str,
+    parameter_set: str,
+    overrides: Mapping[str, object],
+    t_eval: Optional[Iterable[float]] = None,
+    extra_variables: Optional[Iterable[str]] = None,
+) -> Dict[str, List[float]]:
+    """Execute a PyBaMM simulation and return the requested result channels.
+
+    Parameters
+    ----------
+    chemistry:
+        Name of the chemistry module to load from :mod:`pybamm` (e.g.
+        ``"lithium_ion"``).
+    model:
+        Model factory exposed by the chosen chemistry (e.g. ``"DFN"``).
+    parameter_set:
+        Identifier of the parameter set defined in :mod:`pybamm.parameter_sets`.
+    overrides:
+        Mapping of PyBaMM parameter names to override values.
+    t_eval:
+        Optional iterable of timestamps (in seconds) to evaluate during the
+        solve. When omitted a one hour discharge sampled every second is used.
+    extra_variables:
+        Additional solution variables to extract from the simulation.
+    """
+
+    try:
+        import pybamm  # type: ignore
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise RuntimeError("PyBaMM is not available in the runtime environment") from exc
+
+    try:
+        chemistry_module = getattr(pybamm, chemistry)
+        model_factory = getattr(chemistry_module, model)
+    except AttributeError as exc:  # pragma: no cover - invalid configuration
+        raise RuntimeError(f"Unknown PyBaMM model '{chemistry}.{model}'") from exc
+
+    if not parameter_set:
+        raise ValueError("No PyBaMM parameter set selected")
+
+    try:
+        parameter_values_source = getattr(pybamm.parameter_sets, parameter_set)
+    except AttributeError as exc:
+        raise RuntimeError(f"Unknown PyBaMM parameter set '{parameter_set}'") from exc
+
+    parameter_values = pybamm.ParameterValues(chemistry=parameter_values_source)
+    if overrides:
+        parameter_values.update(dict(overrides))
+
+    if t_eval is None:
+        t_eval = pybamm.linspace(0, 3600, 361)
+    else:
+        t_eval = [float(value) for value in t_eval]
+
+    model_instance = model_factory()
+    simulation = pybamm.Simulation(model_instance, parameter_values=parameter_values)
+    solution = simulation.solve(t_eval=t_eval)
+
+    results: Dict[str, List[float]] = {
+        "Time [s]": solution.t.tolist(),
+    }
+
+    variables = list(DEFAULT_EXPORT_VARIABLES)
+    if extra_variables:
+        for variable in extra_variables:
+            if variable not in variables:
+                variables.append(variable)
+
+    for variable in variables:
+        try:
+            channel = solution[variable]
+        except KeyError:  # pragma: no cover - variable not produced by model
+            continue
+        results[variable] = channel.entries.tolist()
+
+    return results
+
+
+def export_simulation_results(
+    export_dir: pathlib.Path,
+    prefix: str,
+    results: Mapping[str, Sequence[float]],
+    *,
+    include_mdf: bool = True,
+) -> ExportResult:
+    """Persist simulation results as ``.dat`` (and optionally ``.mdf``) files."""
+
+    export_dir.mkdir(parents=True, exist_ok=True)
+
+    if "Time [s]" not in results:
+        raise ValueError("Simulation results missing 'Time [s]' channel")
+    time = [float(value) for value in results["Time [s]"]]
+    columns = [key for key in results.keys() if key != "Time [s]"]
+    expected_length = len(time)
+
+    column_data: Dict[str, List[float]] = {"Time [s]": time}
+    for column in columns:
+        values = [float(value) for value in results[column]]
+        if len(values) != expected_length:
+            raise ValueError(f"Result channel '{column}' length mismatch")
+        column_data[column] = values
+
+    dat_path = export_dir / f"{prefix}.dat"
+    header = "\t".join(["Time [s]"] + columns)
+    with dat_path.open("w", encoding="utf-8", newline="") as handle:
+        handle.write(f"{header}\n")
+        for row_index in range(expected_length):
+            row_values = [column_data["Time [s]"][row_index]]
+            row_values.extend(column_data[column][row_index] for column in columns)
+            formatted = "\t".join(_format_float(value) for value in row_values)
+            handle.write(f"{formatted}\n")
+
+    mdf_path: Optional[pathlib.Path] = None
+    warnings: List[str] = []
+
+    if include_mdf:
+        try:
+            from asammdf import MDF, Signal  # type: ignore
+        except ImportError:  # pragma: no cover - optional dependency
+            warnings.append("asammdf is not installed; MDF export skipped")
+        else:
+            signals = []
+            for column in columns:
+                samples = [float(value) for value in results[column]]
+                signals.append(Signal(samples=samples, timestamps=time, name=column))
+
+            mdf = MDF()
+            mdf.append(signals)
+            mdf_path = export_dir / f"{prefix}.mdf"
+            mdf.save(mdf_path, overwrite=True)
+
+    return ExportResult(dat_path=dat_path, mdf_path=mdf_path, warnings=warnings)
+
+
+def _format_float(value: float) -> str:
+    if value == 0:
+        return "0"
+    magnitude = abs(value)
+    if magnitude != 0 and (magnitude >= 1e4 or magnitude <= 1e-3):
+        return f"{value:.6e}"
+    return f"{value:.12g}"
+
+
+__all__ = [
+    "DEFAULT_EXPORT_VARIABLES",
+    "ExportResult",
+    "export_simulation_results",
+    "run_pybamm_simulation",
+]
+

--- a/app/ui_qt/qml/Main.qml
+++ b/app/ui_qt/qml/Main.qml
@@ -29,7 +29,10 @@ ApplicationWindow {
 
             Button {
                 text: qsTr("Run default scenario")
-                onClicked: simulationController.run_scenario()
+                onClicked: {
+                    simulationController.run_scenario()
+                    parameterBridge.runDefaultSimulation()
+                }
             }
         }
     }
@@ -273,6 +276,7 @@ ApplicationWindow {
                     switch (type) {
                     case "bool": return boolEditor;
                     case "enum": return enumEditor;
+                    case "string": return stringEditor;
                     default: return numberEditor;
                     }
                 }
@@ -326,6 +330,17 @@ ApplicationWindow {
                     let idx = find(value)
                     if (idx >= 0) currentIndex = idx
                 }
+            }
+        }
+    }
+
+    Component {
+        id: stringEditor
+        RowLayout {
+            TextField {
+                Layout.fillWidth: true
+                text: String(value)
+                onEditingFinished: model.value = text
             }
         }
     }
@@ -410,6 +425,9 @@ ApplicationWindow {
             window.progressValue = pct
         }
         onErrorOccurred: function(message) {
+            window.statusMessage = message
+        }
+        onSimulationCompleted: function(message) {
             window.statusMessage = message
         }
     }

--- a/configs/scenarios/default.yaml
+++ b/configs/scenarios/default.yaml
@@ -1,7 +1,8 @@
 pybamm:
   chemistry: lithium_ion
   model: DFN
-  parameter_schema: configs/schemas/pybamm/lithium_ion/DFN.params.json
+  parameter_schema: auto
+  fallback_schema: configs/schemas/pybamm/lithium_ion/DFN.params.json
   presets:
     - id: Chen2020
       label: "Chen et al. 2020"

--- a/tests/python/test_pybamm_runner.py
+++ b/tests/python/test_pybamm_runner.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import pathlib
 import sys
 import tempfile
+import types
 import unittest
+from typing import Dict, List, Optional, Tuple
 
-from app.ui_qt.pybamm_runner import export_simulation_results
+from app.ui_qt.pybamm_runner import export_simulation_results, run_pybamm_simulation
 
 
 class ExportSimulationResultsTest(unittest.TestCase):
@@ -50,6 +52,122 @@ class ExportSimulationResultsTest(unittest.TestCase):
             else:
                 sys.modules.pop("asammdf", None)
 
+
+class RunPyBammSimulationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module_backup = sys.modules.pop("pybamm", None)
+
+    def tearDown(self) -> None:
+        if self.module_backup is not None:
+            sys.modules["pybamm"] = self.module_backup
+        else:
+            sys.modules.pop("pybamm", None)
+
+    def _install_fake_pybamm(self) -> types.SimpleNamespace:
+        fake_module = types.SimpleNamespace()
+
+        class FakeParameterValues:
+            last_instance: Optional["FakeParameterValues"] = None
+
+            def __init__(self, chemistry: object) -> None:
+                self.chemistry = chemistry
+                self.updated_with: Optional[Dict[str, object]] = None
+                FakeParameterValues.last_instance = self
+
+            def update(self, overrides: Dict[str, object]) -> None:
+                self.updated_with = overrides
+
+        class FakeArray:
+            def __init__(self, values: List[float]) -> None:
+                self._values = list(values)
+
+            def tolist(self) -> List[float]:
+                return list(self._values)
+
+            @property
+            def entries(self) -> "FakeArray":
+                return self
+
+        class FakeSolution:
+            def __init__(self, t_eval: List[float]) -> None:
+                self.t = FakeArray(t_eval)
+                self._variables: Dict[str, FakeArray] = {
+                    "Terminal voltage [V]": FakeArray([4.2 for _ in t_eval]),
+                    "Custom": FakeArray(list(range(len(t_eval)))),
+                }
+
+            def __getitem__(self, name: str) -> FakeArray:
+                return self._variables[name]
+
+        class FakeSimulation:
+            last_t_eval: Optional[List[float]] = None
+            last_parameter_values: Optional[FakeParameterValues] = None
+            last_model_instance: Optional[object] = None
+
+            def __init__(self, model_instance: object, parameter_values: FakeParameterValues) -> None:
+                type(self).last_model_instance = model_instance
+                type(self).last_parameter_values = parameter_values
+
+            def solve(self, t_eval: List[float]) -> FakeSolution:
+                type(self).last_t_eval = [float(value) for value in t_eval]
+                return FakeSolution(type(self).last_t_eval)
+
+        def fake_model_factory() -> dict[str, str]:
+            return {"model": "dfn"}
+
+        def fake_linspace(start: float, stop: float, count: int) -> List[float]:
+            fake_module.linspace_args = (start, stop, count)
+            if count <= 1:
+                return [float(start)]
+            step = (stop - start) / (count - 1)
+            return [float(start + step * index) for index in range(count)]
+
+        fake_module.ParameterValues = FakeParameterValues
+        fake_module.Simulation = FakeSimulation
+        fake_module.linspace = fake_linspace
+        fake_module.linspace_args: Optional[Tuple[float, float, int]] = None
+        fake_module.parameter_sets = types.SimpleNamespace(TestSet="chemistry_source")
+        fake_module.lithium_ion = types.SimpleNamespace(DFN=fake_model_factory)
+
+        sys.modules["pybamm"] = fake_module
+        return fake_module
+
+    def test_runs_simulation_with_overrides_and_extra_variables(self) -> None:
+        fake_module = self._install_fake_pybamm()
+
+        results = run_pybamm_simulation(
+            chemistry="lithium_ion",
+            model="DFN",
+            parameter_set="TestSet",
+            overrides={"My parameter": 3.14},
+            t_eval=[0, 10, 20],
+            extra_variables=["Custom"],
+        )
+
+        self.assertIn("Time [s]", results)
+        self.assertEqual(results["Time [s]"], [0.0, 10.0, 20.0])
+        self.assertEqual(results["Custom"], [0, 1, 2])
+        parameter_values = fake_module.ParameterValues.last_instance
+        self.assertIsNotNone(parameter_values)
+        self.assertEqual(parameter_values.chemistry, "chemistry_source")
+        self.assertEqual(parameter_values.updated_with, {"My parameter": 3.14})
+        self.assertEqual(fake_module.Simulation.last_t_eval, [0.0, 10.0, 20.0])
+        self.assertEqual(fake_module.Simulation.last_model_instance, {"model": "dfn"})
+
+    def test_uses_default_time_grid_when_t_eval_missing(self) -> None:
+        fake_module = self._install_fake_pybamm()
+
+        results = run_pybamm_simulation(
+            chemistry="lithium_ion",
+            model="DFN",
+            parameter_set="TestSet",
+            overrides={},
+        )
+
+        self.assertIn("Time [s]", results)
+        self.assertEqual(fake_module.linspace_args, (0, 3600, 361))
+        self.assertEqual(len(results["Time [s]"]), 361)
+        self.assertEqual(len(results["Terminal voltage [V]"]), 361)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/python/test_pybamm_runner.py
+++ b/tests/python/test_pybamm_runner.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+import unittest
+
+from app.ui_qt.pybamm_runner import export_simulation_results
+
+
+class ExportSimulationResultsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.results = {
+            "Time [s]": [0.0, 1.0, 2.0],
+            "Terminal voltage [V]": [4.2, 4.1, 4.0],
+        }
+
+    def test_writes_dat_without_mdf(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            export_dir = pathlib.Path(tmpdir)
+            export = export_simulation_results(
+                export_dir,
+                "smoke",
+                self.results,
+                include_mdf=False,
+            )
+            self.assertTrue(export.dat_path.exists())
+            self.assertEqual(export.dat_path.suffix, ".dat")
+            self.assertIsNone(export.mdf_path)
+            self.assertFalse(export.warnings)
+            content = export.dat_path.read_text(encoding="utf-8")
+            self.assertIn("Time [s]\tTerminal voltage [V]", content.splitlines()[0])
+
+    def test_warns_when_asammdf_missing(self) -> None:
+        module_backup = sys.modules.pop("asammdf", None)
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                export = export_simulation_results(
+                    pathlib.Path(tmpdir),
+                    "missing_mdf",
+                    self.results,
+                    include_mdf=True,
+                )
+            self.assertTrue(export.warnings)
+            self.assertIsNone(export.mdf_path)
+            self.assertIn("asammdf", export.warnings[0])
+        finally:
+            if module_backup is not None:
+                sys.modules["asammdf"] = module_backup
+            else:
+                sys.modules.pop("asammdf", None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract the PyBaMM simulation/export pipeline into a standalone helper that gracefully skips MDF generation when asammdf is missing
- update the Qt bridge to use the shared helper and include dependency warnings in the completion message
- exercise the DAT export path with unit tests and document the MDF dependency as optional in the README

## Testing
- python -m compileall app/ui_qt
- python -m unittest discover tests/python

------
https://chatgpt.com/codex/tasks/task_e_68da140d4b0c83338b4c222b01cdda25