### PR TITLE
Handle script execution import in parameter bridge

### DIFF
--- a/app/ui_qt/parameter_bridge.py
+++ b/app/ui_qt/parameter_bridge.py
@@ -8,7 +8,10 @@ from datetime import datetime
 import re
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple
 
-from .pybamm_runner import export_simulation_results, run_pybamm_simulation
+if __package__:
+    from .pybamm_runner import export_simulation_results, run_pybamm_simulation
+else:  # pragma: no cover - executed when running as a script
+    from pybamm_runner import export_simulation_results, run_pybamm_simulation
 
 
 def _serialise_value(value: Any) -> Any:


### PR DESCRIPTION
## Summary
- adjust `parameter_bridge` to import `pybamm_runner` correctly when executed as a script
- maintain the existing relative import when the module is part of the package

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da2318320c833392b56b9939ca3400