### PR TITLE
Add schema-driven PyBaMM parameter UI scaffolding

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ from PySide6.QtGui import QGuiApplication
 from PySide6.QtQml import QQmlApplicationEngine
 
 from model.param_catalog import ParamCatalog
-from model.param_store import ParamStore, bulk_apply
+from model.param_store import ParamStore
 from model.exporters import (
     export_params_csv,
     export_params_dat,
@@ -51,7 +51,7 @@ class Bridge(QObject):
                 values = read_params_dat(normalized)
             else:
                 return
-            bulk_apply(self._store, values)
+            self._store.setValues(values)
         except (FileNotFoundError, JSONDecodeError, OSError, ValueError) as exc:
             print(f"Import failed: {exc}")
 

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from json import JSONDecodeError
 
 from PySide6.QtCore import QObject, QUrl, Slot
 from PySide6.QtGui import QGuiApplication
@@ -51,7 +52,7 @@ class Bridge(QObject):
             else:
                 return
             bulk_apply(self._store, values)
-        except Exception as exc:  # noqa: BLE001
+        except (FileNotFoundError, JSONDecodeError, OSError, ValueError) as exc:
             print(f"Import failed: {exc}")
 
     @Slot(str, str)
@@ -70,7 +71,7 @@ class Bridge(QObject):
                 export_params_dat(target, values_si)
             else:
                 export_params_json(target, values_si)
-        except Exception as exc:  # noqa: BLE001
+        except (OSError, RuntimeError) as exc:
             print(f"Export failed: {exc}")
 
     @Slot(str, str)
@@ -86,7 +87,7 @@ class Bridge(QObject):
                 export_timeseries_mdf4(target, series)
             else:
                 export_timeseries_csv(target, series)
-        except Exception as exc:  # noqa: BLE001
+        except (ValueError, RuntimeError, OSError) as exc:
             print(f"Simulation failed: {exc}")
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -71,7 +71,9 @@ class Bridge(QObject):
                 export_params_dat(target, values_si)
             else:
                 export_params_json(target, values_si)
-        except (OSError, RuntimeError) as exc:
+        except (FileNotFoundError, PermissionError) as exc:
+            print(f"Export failed: {exc}")
+        except OSError as exc:
             print(f"Export failed: {exc}")
 
     @Slot(str, str)
@@ -87,7 +89,11 @@ class Bridge(QObject):
                 export_timeseries_mdf4(target, series)
             else:
                 export_timeseries_csv(target, series)
-        except (ValueError, RuntimeError, OSError) as exc:
+        except RuntimeError as exc:
+            print(f"Simulation failed: {exc}")
+        except (FileNotFoundError, PermissionError) as exc:
+            print(f"Simulation failed: {exc}")
+        except OSError as exc:
             print(f"Simulation failed: {exc}")
 
 

--- a/app/model/exporters.py
+++ b/app/model/exporters.py
@@ -1,49 +1,103 @@
 from __future__ import annotations
 
 import csv
+import json
 from pathlib import Path
 from typing import Any, Dict
 
+try:  # pragma: no cover - optional dependency
+    from asammdf import MDF, Signal  # type: ignore
 
-class ExportError(RuntimeError):
-    """Raised when an export operation fails."""
-
-
-def export_json(values: Dict[str, Any], destination: str | Path) -> None:
-    import json
-
-    path = Path(destination)
-    with path.open("w", encoding="utf-8") as handle:
-        json.dump(values, handle, indent=2, sort_keys=True)
+    HAS_ASAMMDF = True
+except Exception:  # noqa: BLE001
+    HAS_ASAMMDF = False
 
 
-def export_csv(values: Dict[str, Any], destination: str | Path) -> None:
-    path = Path(destination)
-    with path.open("w", encoding="utf-8", newline="") as handle:
+def export_params_json(path: str | Path, params: Dict[str, Any]) -> None:
+    destination = Path(path)
+    with destination.open("w", encoding="utf-8") as handle:
+        json.dump(params, handle, indent=2, ensure_ascii=False)
+
+
+def export_params_csv(path: str | Path, params: Dict[str, Any]) -> None:
+    destination = Path(path)
+    with destination.open("w", encoding="utf-8", newline="") as handle:
         writer = csv.writer(handle)
-        for key, value in values.items():
+        writer.writerow(["key", "value"])
+        for key, value in params.items():
             writer.writerow([key, value])
 
 
-def export_dat(values: Dict[str, Any], destination: str | Path) -> None:
-    path = Path(destination)
-    with path.open("w", encoding="utf-8") as handle:
-        for key, value in values.items():
-            handle.write(f"{key} = {value}\n")
+def export_params_dat(path: str | Path, params: Dict[str, Any]) -> None:
+    destination = Path(path)
+    with destination.open("w", encoding="utf-8") as handle:
+        handle.write("# PyBaMM Parameters (SI)\n")
+        for key, value in params.items():
+            handle.write(f"{key}={value}\n")
 
 
-def export_mdf(values: Dict[str, Any], destination: str | Path) -> None:
-    path = Path(destination)
-    with path.open("w", encoding="utf-8") as handle:
-        handle.write("; MDF4 export is not yet implemented.\n")
-        for key, value in values.items():
-            handle.write(f"; {key} = {value}\n")
+def export_timeseries_csv(path: str | Path, series: Dict[str, list | tuple]) -> None:
+    destination = Path(path)
+    keys = list(series.keys())
+    rows = zip(*[series[k] for k in keys]) if keys else []
+    with destination.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(keys)
+        for row in rows:
+            writer.writerow(row)
 
 
-EXPORTERS = {
-    ".json": export_json,
-    ".csv": export_csv,
-    ".dat": export_dat,
-    ".mdf": export_mdf,
-    ".mdf4": export_mdf,
-}
+def export_timeseries_mdf4(path: str | Path, series: Dict[str, list | tuple], rate_hz: float | None = None) -> None:
+    if not HAS_ASAMMDF:
+        raise RuntimeError("asammdf not installed. Install `asammdf` to enable MDF4 export.")
+    import numpy as np
+
+    destination = Path(path)
+    mdf = MDF()
+    keys = list(series.keys())
+    if not keys:
+        mdf.save(destination)
+        return
+    length = len(series[keys[0]])
+    timestamps = np.arange(length) / (rate_hz or 1.0)
+    for key in keys:
+        data = np.asarray(series[key])
+        signal = Signal(data=data, timestamps=timestamps, name=key)
+        mdf.append(signal)
+    mdf.save(destination)
+
+
+def read_params_json(path: str | Path) -> Dict[str, Any]:
+    source = Path(path)
+    with source.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def read_params_dat(path: str | Path) -> Dict[str, Any]:
+    source = Path(path)
+    params: Dict[str, Any] = {}
+    with source.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            try:
+                params[key] = float(value)
+            except ValueError:
+                params[key] = value
+    return params
+
+
+def read_timeseries_mdf4(path: str | Path) -> Dict[str, list]:
+    if not HAS_ASAMMDF:
+        raise RuntimeError("asammdf not installed. Install `asammdf` to enable MDF4 read.")
+    source = Path(path)
+    mdf = MDF(source)
+    data: Dict[str, list] = {}
+    for channel in mdf.channels_db:  # type: ignore[attr-defined]
+        signal = mdf.get(channel)
+        data[channel] = signal.samples.tolist()
+    return data

--- a/app/model/exporters.py
+++ b/app/model/exporters.py
@@ -84,6 +84,8 @@ def read_params_dat(path: str | Path) -> Dict[str, Any]:
             if "=" not in line:
                 continue
             key, value = line.split("=", 1)
+            key = key.strip()
+            value = value.strip()
             try:
                 params[key] = float(value)
             except ValueError:

--- a/app/model/exporters.py
+++ b/app/model/exporters.py
@@ -83,9 +83,9 @@ def read_params_dat(path: str | Path) -> Dict[str, Any]:
                 continue
             if "=" not in line:
                 continue
-            key, value = line.split("=", 1)
-            key = key.strip()
-            value = value.strip()
+            key_raw, value_raw = line.split("=", 1)
+            key = key_raw.strip()
+            value = value_raw.strip()
             try:
                 params[key] = float(value)
             except ValueError:

--- a/app/model/param_store.py
+++ b/app/model/param_store.py
@@ -36,6 +36,11 @@ class ParamStore(QObject):
     def getValue(self, key: str) -> Any:  # noqa: N802 - Qt slot naming
         return self._values.get(key)
 
+    @Slot("QVariantMap")
+    def setValues(self, values: Dict[str, Any]) -> None:
+        for key, value in values.items():
+            self.setValue(key, value)
+
     @Property("QVariant", constant=True)
     def values(self) -> Dict[str, Any]:  # noqa: D401
 
@@ -44,4 +49,9 @@ class ParamStore(QObject):
     @Slot(result="QVariant")
     def defaults(self) -> Dict[str, Any]:
         return dict(self._iter_default_items())
+
+
+def bulk_apply(store: "ParamStore", values: Dict[str, Any]) -> None:
+    for key, value in values.items():
+        store.setValue(key, value)
 

--- a/app/model/param_store.py
+++ b/app/model/param_store.py
@@ -49,9 +49,3 @@ class ParamStore(QObject):
     @Slot(result="QVariant")
     def defaults(self) -> Dict[str, Any]:
         return dict(self._iter_default_items())
-
-
-def bulk_apply(store: "ParamStore", values: Dict[str, Any]) -> None:
-    for key, value in values.items():
-        store.setValue(key, value)
-

--- a/app/model/runner.py
+++ b/app/model/runner.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, Tuple
+
+from .units_adapter import convert_to_si, values_to_pybamm_keys
+
+if TYPE_CHECKING:  # pragma: no cover
+    import pybamm as pb
+
+
+def _lazy_import_pybamm():
+    try:
+        import pybamm as pb  # type: ignore
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "PyBaMM is required to run simulations. Install it with `pip install pybamm`."
+        ) from exc
+    return pb
+
+
+def build_experiment(ui_values: Dict[str, Any], pb=None):
+    if pb is None:
+        pb = _lazy_import_pybamm()
+    current = float(ui_values.get("operating.cc_current", 1.0))
+    cv_voltage = float(ui_values.get("operating.cv_voltage", 4.2))
+    v_min = float(ui_values.get("operating.v_min", 2.8))
+    v_max = float(ui_values.get("operating.v_max", 4.2))
+    steps = [
+        (f"Charge at {current} A until {v_max} V",),
+        (f"Hold at {cv_voltage} V until 50 mA",),
+        ("Rest for 600 seconds",),
+        (f"Discharge at {current} A until {v_min} V",),
+        ("Rest for 600 seconds",),
+    ]
+    return pb.Experiment(steps)
+
+
+def select_model(kind: str | None, pb=None):
+    if pb is None:
+        pb = _lazy_import_pybamm()
+    kind_upper = (kind or "DFN").upper()
+    if kind_upper == "SPM":
+        return pb.lithium_ion.SPM()
+    if kind_upper == "SPME":
+        return pb.lithium_ion.SPMe()
+    return pb.lithium_ion.DFN()
+
+
+def run(ui_values: Dict[str, Any], categories_schema: list[dict]):
+    pb = _lazy_import_pybamm()
+    model = select_model(ui_values.get("model.type"), pb=pb)
+    values_si = convert_to_si(ui_values, categories_schema)
+    parameters = pb.ParameterValues(values_to_pybamm_keys(values_si))
+    experiment = build_experiment(ui_values, pb=pb)
+    simulation = pb.Simulation(model, parameter_values=parameters, experiment=experiment)
+    solution = simulation.solve()
+    context = {
+        "model": model.__class__.__name__,
+        "experiment_summary": str(experiment.operating_conditions_strings),
+    }
+    return solution, context
+
+
+def extract_series(solution):
+    _lazy_import_pybamm()  # ensure dependency present
+    series: Dict[str, list] = {"time [s]": solution.t.tolist()}
+
+    def try_get(name: str) -> list | None:
+        try:
+            return solution[name](solution.t).full().flatten().tolist()
+        except Exception:  # noqa: BLE001 - PyBaMM raises many custom exceptions
+            return None
+
+    for variable in [
+        "Voltage [V]",
+        "Current [A]",
+        "Cell temperature [K]",
+        "Discharge capacity [A.h]",
+        "State of Charge",
+    ]:
+        values = try_get(variable)
+        if values is not None:
+            series[variable] = values
+    return series

--- a/app/model/units_adapter.py
+++ b/app/model/units_adapter.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+# Simple unit multipliers to SI (scalars only)
+UNIT_TO_SI: dict[str, float] = {
+    "μm": 1e-6,
+    "um": 1e-6,
+    "nm": 1e-9,
+    "mm": 1e-3,
+    "cm": 1e-2,
+    "m": 1.0,
+    "A.h": 1.0,
+    "Ah": 1.0,
+    "A": 1.0,
+    "V": 1.0,
+    "K": 1.0,
+    "s": 1.0,
+    "%": 1e-2,
+    "S/m": 1.0,
+    "W/(m·K)": 1.0,
+    "W/(m^2·K)": 1.0,
+    "J/K": 1.0,
+}
+
+# UI key → canonical PyBaMM parameter key
+PYBAMM_KEY_MAP: dict[str, str] = {
+    # Geometry
+    "geometry.anode.thickness": "Negative electrode thickness [m]",
+    "geometry.cathode.thickness": "Positive electrode thickness [m]",
+    "geometry.separator.thickness": "Separator thickness [m]",
+    "geometry.anode.particle_radius": "Negative particle radius [m]",
+    "geometry.cathode.particle_radius": "Positive particle radius [m]",
+
+    # Cell basics
+    "cell.nominal_capacity": "Nominal cell capacity [A.h]",
+    "cell.rated_voltage": "Rated voltage [V]",
+
+    # Initial conditions
+    "initial.soc": "Initial State of Charge",
+    "initial.temperature": "Initial temperature [K]",
+
+    # Thermal
+    "thermal.heat_capacity": "Cell heat capacity [J.K-1]",
+    "thermal.conductivity_axial": "Cell thermal conductivity [W.m-1.K-1]",
+    "thermal.conductivity_radial": "Cell thermal conductivity [W.m-1.K-1]",
+    "thermal.ambient_temp": "Ambient temperature [K]",
+    "thermal.h_coeff": "Heat transfer coefficient [W.m-2.K-1]",
+
+    # Transport (constant overrides)
+    "transport.solid.anode_conductivity": "Negative electrode conductivity [S.m-1]",
+    "transport.solid.cathode_conductivity": "Positive electrode conductivity [S.m-1]",
+    "transport.electrolyte.t_plus": "Electrolyte transference number",
+
+    # Kinetics
+    "kinetics.anode.alpha": "Negative electrode charge transfer coefficient",
+    "kinetics.cathode.alpha": "Positive electrode charge transfer coefficient",
+}
+
+# Keys whose UI unit is "°C" and must be shifted to K
+CELSIUS_KEYS = {"initial.temperature", "thermal.ambient_temp"}
+
+
+def _build_unit_index(categories: list[dict]) -> dict[str, dict]:
+    idx: dict[str, dict] = {}
+    for cat in categories:
+        for sec in cat.get("sections", []):
+            for field in sec.get("fields", []):
+                idx[field["key"]] = {
+                    "unit": field.get("unit"),
+                    "advanced": field.get("advanced", False),
+                }
+    return idx
+
+
+def convert_to_si(values: Dict[str, Any], categories_schema: list[dict]) -> Dict[str, Any]:
+    unit_idx = _build_unit_index(categories_schema)
+    out: Dict[str, Any] = {}
+    for key, value in values.items():
+        meta = unit_idx.get(key, {})
+        unit = meta.get("unit")
+        if isinstance(value, (int, float)):
+            if key in CELSIUS_KEYS:
+                out[key] = float(value) + 273.15 if unit in ("°C", "C") else float(value)
+            elif unit in UNIT_TO_SI:
+                out[key] = float(value) * UNIT_TO_SI[unit]
+            else:
+                out[key] = float(value)
+        else:
+            out[key] = value
+    return out
+
+
+def values_to_pybamm_keys(values_si: Dict[str, Any]) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for key, value in values_si.items():
+        out[PYBAMM_KEY_MAP.get(key, key)] = value
+    return out

--- a/app/params/params_schema.json
+++ b/app/params/params_schema.json
@@ -12,14 +12,24 @@
               "key": "parameter_set",
               "label": "Parameter Set",
               "type": "enum",
-              "options": ["Marquis2019", "Chen2020", "Ecker2015", "Ai2020", "OKane2022", "Custom"],
+              "options": [
+                "Marquis2019",
+                "Chen2020",
+                "Ecker2015",
+                "Ai2020",
+                "OKane2022",
+                "Custom"
+              ],
               "default": "Chen2020"
             },
             {
               "key": "chemistry",
               "label": "Chemistry",
               "type": "enum",
-              "options": ["Li-ion", "Lead-acid"],
+              "options": [
+                "Li-ion",
+                "Lead-acid"
+              ],
               "default": "Li-ion"
             },
             {
@@ -43,23 +53,26 @@
               "default": 3.7
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "id": "model",
+      "label": "Model",
+      "sections": [
         {
-          "label": "Electrodes",
+          "label": "Selection",
           "fields": [
             {
-              "key": "cell.anode_material",
-              "label": "Anode Material",
+              "key": "model.type",
+              "label": "Electrochemical Model",
               "type": "enum",
-              "options": ["Graphite", "Si/Gr", "LTO"],
-              "default": "Graphite"
-            },
-            {
-              "key": "cell.cathode_material",
-              "label": "Cathode Material",
-              "type": "enum",
-              "options": ["NMC", "LFP", "NCA", "LMO"],
-              "default": "NMC"
+              "options": [
+                "DFN",
+                "SPMe",
+                "SPM"
+              ],
+              "default": "DFN"
             }
           ]
         }
@@ -115,7 +128,7 @@
               "min": 0.01,
               "max": 20,
               "step": 0.01,
-              "default": 5.0
+              "default": 5
             },
             {
               "key": "geometry.cathode.particle_radius",
@@ -125,17 +138,7 @@
               "min": 0.01,
               "max": 20,
               "step": 0.01,
-              "default": 5.0
-            },
-            {
-              "key": "geometry.electrode_area",
-              "label": "Electrode Area",
-              "type": "number",
-              "unit": "cm²",
-              "min": 1,
-              "max": 1000,
-              "step": 1,
-              "default": 100
+              "default": 5
             }
           ]
         }
@@ -146,57 +149,27 @@
       "label": "Electrode Kinetics",
       "sections": [
         {
-          "label": "Exchange Current Density",
-          "fields": [
-            {
-              "key": "kinetics.anode.i0_ref",
-              "label": "Anode i₀ (ref)",
-              "type": "number",
-              "unit": "A/m²",
-              "min": 0.01,
-              "max": 1000,
-              "step": 0.01,
-              "default": 3.0
-            },
-            {
-              "key": "kinetics.cathode.i0_ref",
-              "label": "Cathode i₀ (ref)",
-              "type": "number",
-              "unit": "A/m²",
-              "min": 0.01,
-              "max": 1000,
-              "step": 0.01,
-              "default": 6.0
-            }
-          ]
-        },
-        {
-          "label": "Reaction Rates",
+          "label": "Exchange Current",
           "fields": [
             {
               "key": "kinetics.anode.alpha",
-              "label": "Anode Transfer Coefficient",
+              "label": "Anode Transfer Coeff α_an",
               "type": "number",
               "min": 0.1,
-              "max": 1.5,
+              "max": 2.0,
               "step": 0.01,
-              "default": 0.5
+              "default": 0.5,
+              "advanced": true
             },
             {
               "key": "kinetics.cathode.alpha",
-              "label": "Cathode Transfer Coefficient",
+              "label": "Cathode Transfer Coeff α_cat",
               "type": "number",
               "min": 0.1,
-              "max": 1.5,
+              "max": 2.0,
               "step": 0.01,
-              "default": 0.5
-            },
-            {
-              "key": "kinetics.ocp_profile",
-              "label": "Open-circuit Potential",
-              "type": "enum",
-              "options": ["Use preset", "Custom curve"],
-              "default": "Use preset"
+              "default": 0.5,
+              "advanced": true
             }
           ]
         }
@@ -207,27 +180,29 @@
       "label": "Transport",
       "sections": [
         {
-          "label": "Solid",
+          "label": "Solid Phase",
           "fields": [
             {
-              "key": "transport.anode.solid_conductivity",
-              "label": "Anode σₛ",
+              "key": "transport.solid.anode_conductivity",
+              "label": "Anode Conductivity σ_s⁻",
               "type": "number",
               "unit": "S/m",
-              "min": 1,
-              "max": 1e5,
-              "step": 1,
-              "default": 100
+              "min": 1000,
+              "max": 10000000,
+              "step": 1000,
+              "default": 100000,
+              "advanced": true
             },
             {
-              "key": "transport.cathode.solid_conductivity",
-              "label": "Cathode σₛ",
+              "key": "transport.solid.cathode_conductivity",
+              "label": "Cathode Conductivity σ_s⁺",
               "type": "number",
               "unit": "S/m",
-              "min": 1,
-              "max": 1e5,
-              "step": 1,
-              "default": 50
+              "min": 1000,
+              "max": 10000000,
+              "step": 1000,
+              "default": 100000,
+              "advanced": true
             }
           ]
         },
@@ -235,33 +210,13 @@
           "label": "Electrolyte",
           "fields": [
             {
-              "key": "transport.electrolyte.conductivity",
-              "label": "Electrolyte κₑ",
-              "type": "number",
-              "unit": "S/m",
-              "min": 0.01,
-              "max": 1000,
-              "step": 0.01,
-              "default": 1.0
-            },
-            {
-              "key": "transport.electrolyte.diffusivity",
-              "label": "Electrolyte Diffusivity",
-              "type": "number",
-              "unit": "m²/s",
-              "min": 1e-14,
-              "max": 1e-9,
-              "step": 1e-14,
-              "default": 5e-11
-            },
-            {
-              "key": "transport.transference_number",
+              "key": "transport.electrolyte.t_plus",
               "label": "Transference Number t⁺",
               "type": "number",
-              "min": 0.1,
-              "max": 0.9,
+              "min": 0.0,
+              "max": 1.0,
               "step": 0.01,
-              "default": 0.4
+              "default": 0.38
             }
           ]
         }
@@ -272,188 +227,101 @@
       "label": "Thermodynamics & Thermal",
       "sections": [
         {
-          "label": "Thermodynamics",
+          "label": "Bulk",
           "fields": [
             {
-              "key": "thermal.entropic_coefficient",
-              "label": "Entropic Coefficient",
+              "key": "thermal.heat_capacity",
+              "label": "Heat Capacity",
               "type": "number",
-              "unit": "V/K",
-              "min": -0.5,
-              "max": 0.5,
-              "step": 0.001,
-              "default": 0.0
+              "unit": "J/K",
+              "min": 10,
+              "max": 1000000,
+              "step": 10,
+              "default": 900
             },
             {
-              "key": "thermal.heat_capacity",
-              "label": "Cell Heat Capacity",
+              "key": "thermal.conductivity_axial",
+              "label": "Conductivity (Axial)",
               "type": "number",
-              "unit": "J/kg·K",
-              "min": 100,
-              "max": 2000,
-              "step": 1,
-              "default": 900
+              "unit": "W/(m·K)",
+              "min": 0.1,
+              "max": 1000,
+              "step": 0.1,
+              "default": 5.0
+            },
+            {
+              "key": "thermal.conductivity_radial",
+              "label": "Conductivity (Radial)",
+              "type": "number",
+              "unit": "W/(m·K)",
+              "min": 0.1,
+              "max": 1000,
+              "step": 0.1,
+              "default": 5.0
             }
           ]
         },
         {
-          "label": "Thermal",
+          "label": "Boundary",
           "fields": [
             {
-              "key": "thermal.conductivity_radial",
-              "label": "Thermal Conductivity (radial)",
-              "type": "number",
-              "unit": "W/m·K",
-              "min": 0.1,
-              "max": 20,
-              "step": 0.1,
-              "default": 1.5
-            },
-            {
-              "key": "thermal.conductivity_axial",
-              "label": "Thermal Conductivity (axial)",
-              "type": "number",
-              "unit": "W/m·K",
-              "min": 0.1,
-              "max": 20,
-              "step": 0.1,
-              "default": 3.0
-            },
-            {
-              "key": "thermal.ambient_temperature",
+              "key": "thermal.ambient_temp",
               "label": "Ambient Temperature",
               "type": "number",
-              "unit": "°C",
-              "min": -40,
-              "max": 80,
-              "step": 1,
-              "default": 25
+              "unit": "K",
+              "min": 200,
+              "max": 400,
+              "step": 0.5,
+              "default": 298.15
             },
             {
-              "key": "thermal.convection_coefficient",
-              "label": "Convection Coefficient",
+              "key": "thermal.h_coeff",
+              "label": "Convection Coefficient h",
               "type": "number",
-              "unit": "W/m²·K",
-              "min": 1,
-              "max": 100,
-              "step": 1,
-              "default": 10
+              "unit": "W/(m^2·K)",
+              "min": 0.0,
+              "max": 1000.0,
+              "step": 0.5,
+              "default": 10.0
             }
           ]
         }
       ]
     },
     {
-      "id": "degradation",
-      "label": "SEI / Degradation",
+      "id": "sei",
+      "label": "SEI & Degradation",
       "sections": [
         {
-          "label": "SEI",
+          "label": "Models",
           "fields": [
             {
               "key": "sei.enabled",
               "label": "Enable SEI Growth",
               "type": "bool",
-              "default": true
-            },
-            {
-              "key": "sei.k_sei",
-              "label": "SEI Kinetic Rate",
-              "type": "number",
-              "unit": "m/s",
-              "min": 1e-20,
-              "max": 1e-10,
-              "step": 1e-20,
-              "default": 1e-14
-            },
-            {
-              "key": "sei.activation_energy",
-              "label": "SEI Activation Energy",
-              "type": "number",
-              "unit": "J/mol",
-              "min": 0,
-              "max": 2e5,
-              "step": 100,
-              "default": 4.5e4
-            }
-          ]
-        },
-        {
-          "label": "Lithium Plating",
-          "fields": [
-            {
-              "key": "plating.enabled",
-              "label": "Enable Lithium Plating",
-              "type": "bool",
               "default": false
             },
             {
-              "key": "plating.exchange_current_density",
-              "label": "Plating Exchange Current",
-              "type": "number",
-              "unit": "A/m²",
-              "min": 0.0,
-              "max": 100,
-              "step": 0.01,
-              "default": 0.1
-            }
-          ]
-        },
-        {
-          "label": "Aging",
-          "fields": [
-            {
-              "key": "aging.loss_active_material",
-              "label": "Loss of Active Material",
-              "type": "number",
-              "unit": "%/cycle",
-              "min": 0.0,
-              "max": 5.0,
-              "step": 0.01,
-              "default": 0.02
-            },
-            {
-              "key": "aging.resistance_growth",
-              "label": "Resistance Growth",
-              "type": "number",
-              "unit": "%/cycle",
-              "min": 0.0,
-              "max": 5.0,
-              "step": 0.01,
-              "default": 0.05
+              "key": "plating.enabled",
+              "label": "Enable Li Plating",
+              "type": "bool",
+              "default": false,
+              "advanced": true
             }
           ]
         }
       ]
     },
     {
-      "id": "initial_conditions",
+      "id": "initial",
       "label": "Initial Conditions",
       "sections": [
         {
           "label": "State",
           "fields": [
             {
-              "key": "initial.anode_stoichiometry",
-              "label": "Anode Stoichiometry x₀",
-              "type": "number",
-              "min": 0.0,
-              "max": 1.0,
-              "step": 0.01,
-              "default": 0.2
-            },
-            {
-              "key": "initial.cathode_stoichiometry",
-              "label": "Cathode Stoichiometry x₀",
-              "type": "number",
-              "min": 0.0,
-              "max": 1.0,
-              "step": 0.01,
-              "default": 0.8
-            },
-            {
               "key": "initial.soc",
-              "label": "Initial State of Charge",
+              "label": "Initial SOC",
               "type": "number",
               "unit": "%",
               "min": 0,
@@ -465,11 +333,11 @@
               "key": "initial.temperature",
               "label": "Initial Temperature",
               "type": "number",
-              "unit": "°C",
-              "min": -40,
-              "max": 80,
-              "step": 1,
-              "default": 25
+              "unit": "K",
+              "min": 200,
+              "max": 400,
+              "step": 0.5,
+              "default": 298.15
             }
           ]
         }
@@ -484,68 +352,43 @@
           "fields": [
             {
               "key": "operating.cc_current",
-              "label": "Constant Current",
+              "label": "CC Current",
               "type": "number",
               "unit": "A",
-              "min": -500,
+              "min": 0.01,
               "max": 500,
-              "step": 0.1,
+              "step": 0.01,
               "default": 1.0
             },
             {
               "key": "operating.cv_voltage",
-              "label": "Constant Voltage",
+              "label": "CV Voltage",
               "type": "number",
               "unit": "V",
               "min": 1.0,
               "max": 5.0,
               "step": 0.01,
               "default": 4.2
-            }
-          ]
-        },
-        {
-          "label": "Limits",
-          "fields": [
+            },
             {
-              "key": "operating.cutoff_voltage_min",
-              "label": "Cutoff Voltage Min",
+              "key": "operating.v_min",
+              "label": "Cutoff V_min",
               "type": "number",
               "unit": "V",
-              "min": 1.5,
+              "min": 1.0,
               "max": 4.0,
               "step": 0.01,
               "default": 2.8
             },
             {
-              "key": "operating.cutoff_voltage_max",
-              "label": "Cutoff Voltage Max",
+              "key": "operating.v_max",
+              "label": "Cutoff V_max",
               "type": "number",
               "unit": "V",
               "min": 3.5,
-              "max": 4.5,
+              "max": 5.0,
               "step": 0.01,
               "default": 4.2
-            },
-            {
-              "key": "operating.cutoff_current",
-              "label": "Current Limit",
-              "type": "number",
-              "unit": "A",
-              "min": 0.1,
-              "max": 500,
-              "step": 0.1,
-              "default": 50
-            },
-            {
-              "key": "operating.temperature_max",
-              "label": "Temperature Limit",
-              "type": "number",
-              "unit": "°C",
-              "min": 0,
-              "max": 120,
-              "step": 1,
-              "default": 60
             }
           ]
         }
@@ -560,26 +403,30 @@
           "fields": [
             {
               "key": "solver.type",
-              "label": "Solver Type",
+              "label": "Solver",
               "type": "enum",
-              "options": ["CasADI", "Scikits", "IDA"],
-              "default": "CasADI"
+              "options": [
+                "IDA",
+                "CasADI",
+                "Scikits"
+              ],
+              "default": "IDA"
             },
             {
               "key": "solver.rtol",
-              "label": "Relative Tolerance",
+              "label": "Rel Tol (rtol)",
               "type": "number",
-              "min": 1e-10,
+              "min": 1e-9,
               "max": 1e-2,
-              "step": 1e-10,
+              "step": 1e-9,
               "default": 1e-6
             },
             {
               "key": "solver.atol",
-              "label": "Absolute Tolerance",
+              "label": "Abs Tol (atol)",
               "type": "number",
               "min": 1e-12,
-              "max": 1e-3,
+              "max": 1e-4,
               "step": 1e-12,
               "default": 1e-8
             }
@@ -589,50 +436,34 @@
           "label": "Mesh",
           "fields": [
             {
-              "key": "mesh.anode_points",
-              "label": "Anode Points",
+              "key": "mesh.points.anode",
+              "label": "Mesh Points (Anode)",
               "type": "number",
-              "min": 5,
+              "min": 4,
               "max": 200,
               "step": 1,
-              "default": 40
+              "default": 32,
+              "advanced": true
             },
             {
-              "key": "mesh.separator_points",
-              "label": "Separator Points",
+              "key": "mesh.points.separator",
+              "label": "Mesh Points (Separator)",
               "type": "number",
-              "min": 5,
+              "min": 4,
               "max": 200,
               "step": 1,
-              "default": 20
+              "default": 16,
+              "advanced": true
             },
             {
-              "key": "mesh.cathode_points",
-              "label": "Cathode Points",
+              "key": "mesh.points.cathode",
+              "label": "Mesh Points (Cathode)",
               "type": "number",
-              "min": 5,
+              "min": 4,
               "max": 200,
               "step": 1,
-              "default": 40
-            },
-            {
-              "key": "mesh.particle_points",
-              "label": "Particle Points",
-              "type": "number",
-              "min": 5,
-              "max": 100,
-              "step": 1,
-              "default": 20
-            },
-            {
-              "key": "solver.max_step",
-              "label": "Max Step",
-              "type": "number",
-              "unit": "s",
-              "min": 0.01,
-              "max": 600,
-              "step": 0.01,
-              "default": 60
+              "default": 32,
+              "advanced": true
             }
           ]
         }
@@ -643,30 +474,25 @@
       "label": "Outputs & Logging",
       "sections": [
         {
-          "label": "Channels",
+          "label": "Signals",
           "fields": [
             {
               "key": "outputs.channels",
-              "label": "Channels",
-              "type": "text",
-              "default": "V,I,SOC,T"
-            },
-            {
-              "key": "outputs.sampling_rate",
-              "label": "Sampling Rate",
-              "type": "number",
-              "unit": "Hz",
-              "min": 0.1,
-              "max": 1000,
-              "step": 0.1,
-              "default": 1.0
-            },
-            {
-              "key": "outputs.format",
-              "label": "Export Format",
+              "label": "Signals to Save",
               "type": "enum",
-              "options": [".csv", ".dat", ".json", ".mdf4"],
-              "default": ".csv"
+              "options": ["V,I,SOC,T,η"],
+              "default": "V,I,SOC",
+              "advanced": true
+            },
+            {
+              "key": "outputs.sample_rate",
+              "label": "Sample Every (s)",
+              "type": "number",
+              "unit": "s",
+              "min": 0.01,
+              "max": 60,
+              "step": 0.01,
+              "default": 1.0
             }
           ]
         }

--- a/app/ui_qt/qml/ParamForm.qml
+++ b/app/ui_qt/qml/ParamForm.qml
@@ -6,6 +6,8 @@ Item {
     id: root
     property var currentSection: ({ category: 0, section: 0 })
     property var categories: ParamCatalog.categories()
+    property string query: ""
+    property bool showAdvanced: false
 
     function safeCategory(index) {
         const cats = root.categories
@@ -57,6 +59,15 @@ Item {
                     }
                     delegate: ParamField {
                         field: modelData
+                        visible: {
+                            const isAdvanced = !!field.advanced
+                            const matchesAdvanced = root.showAdvanced || !isAdvanced
+                            const q = (root.query || "").toLowerCase()
+                            const label = String(field.label || "").toLowerCase()
+                            const key = String(field.key || "").toLowerCase()
+                            const matchesQuery = !q || label.indexOf(q) !== -1 || key.indexOf(q) !== -1
+                            return matchesAdvanced && matchesQuery
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- replace the parameter schema with category and advanced metadata to drive the PyBaMM UI
- add Qt bridge logic, unit conversion helpers, and a PyBaMM runner with importer/exporter updates
- refresh the QML sidebar and form for search, advanced filtering, and run/export flows

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68da3e0b8c948333a95735492f53799c