### PR TITLE
Fix QML dialogs import for Qt 6 compatibility

### DIFF
--- a/app/ui_qt/qml/Main.qml
+++ b/app/ui_qt/qml/Main.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.3
+import QtQuick.Dialogs
 
 ApplicationWindow {
     id: win

--- a/app/ui_qt/qml/Main.qml
+++ b/app/ui_qt/qml/Main.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import QtQuick.Dialogs
 
 ApplicationWindow {

--- a/app/ui_qt/qml/ParamField.qml
+++ b/app/ui_qt/qml/ParamField.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Item {
     id: root

--- a/app/ui_qt/qml/ParamForm.qml
+++ b/app/ui_qt/qml/ParamForm.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Item {
     id: root

--- a/app/ui_qt/qml/Sidebar.qml
+++ b/app/ui_qt/qml/Sidebar.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Item {
     id: root

--- a/app/ui_qt/qml/Toast.qml
+++ b/app/ui_qt/qml/Toast.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 
 Popup {
     id: popup


### PR DESCRIPTION
## Summary
- switch the QML dialogs import to the Qt 6 module so FileDialog types resolve

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da468000c48333a3fd1f5bf1cf519d