### PR TITLE
Add headless Qt UI tests and expose catalog schema

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,2 @@
+"""Application package for the EV simulation UI."""
+

--- a/app/main.py
+++ b/app/main.py
@@ -62,7 +62,7 @@ class Bridge(QObject):
         if target.parent:
             target.parent.mkdir(parents=True, exist_ok=True)
         values = self._store.values
-        schema = self._catalog.categories()
+        schema = self._catalog.categories_schema()
         values_si = convert_to_si(values, schema)
         try:
             if fmt == "csv":
@@ -83,7 +83,7 @@ class Bridge(QObject):
         if target.parent:
             target.parent.mkdir(parents=True, exist_ok=True)
         try:
-            solution, _context = run_sim(self._store.values, self._catalog.categories())
+            solution, _context = run_sim(self._store.values, self._catalog.categories_schema())
             series = extract_series(solution)
             if fmt.lower() == "mdf4":
                 export_timeseries_mdf4(target, series)

--- a/app/model/param_catalog.py
+++ b/app/model/param_catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import copy
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator, Sequence
@@ -55,7 +56,7 @@ class ParamCatalog(QObject):
     def categories_schema(self) -> list[dict[str, Any]]:
         """Return a deep copy of the raw category schema for Python callers."""
 
-        return json.loads(json.dumps(self._categories))
+        return copy.deepcopy(self._categories)
 
     @Property("QVariant", constant=True)
     def categories(self) -> list[dict[str, Any]]:

--- a/app/model/param_catalog.py
+++ b/app/model/param_catalog.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator, Sequence
 
+from PySide6.QtCore import QObject, Property, Slot
+
 
 @dataclass(frozen=True)
 class Field:
@@ -22,10 +24,15 @@ class Field:
 
 
 
-class ParamCatalog:
+class ParamCatalog(QObject):
     """Lightweight wrapper around the parameter schema for QML."""
 
-    def __init__(self, categories: Sequence[dict[str, Any]]):
+    def __init__(
+        self,
+        categories: Sequence[dict[str, Any]],
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
         self._categories = list(categories)
 
         self._fields_by_key: dict[str, dict[str, Any]] = {}
@@ -38,15 +45,21 @@ class ParamCatalog:
 
 
     @classmethod
-    def from_json(cls, path: str | Path) -> "ParamCatalog":
+    def from_json(cls, path: str | Path, parent: QObject | None = None) -> "ParamCatalog":
         schema_path = Path(path)
         with schema_path.open("r", encoding="utf-8") as handle:
             data = json.load(handle)
         categories = data.get("categories", [])
-        return cls(categories)
+        return cls(categories, parent=parent)
 
+    def categories_schema(self) -> list[dict[str, Any]]:
+        """Return a deep copy of the raw category schema for Python callers."""
+
+        return json.loads(json.dumps(self._categories))
+
+    @Property("QVariant", constant=True)
     def categories(self) -> list[dict[str, Any]]:
-        return list(self._categories)
+        return self.categories_schema()
 
     def iter_fields(self) -> Iterator[Field]:
         for category in self._categories:
@@ -58,6 +71,7 @@ class ParamCatalog:
     def _field_by_key(self, key: str) -> dict[str, Any] | None:
         return self._fields_by_key.get(key)
 
+    @Slot(str, result="QVariant")
     def field_options(self, key: str) -> list[Any]:
         """Return the option list for an enum field or an empty list."""
 
@@ -69,6 +83,7 @@ class ParamCatalog:
             return []
         return list(options)
 
+    @Slot(str, result="QVariant")
     def field_default(self, key: str) -> Any | None:
         """Return the default value for a field if specified."""
 

--- a/app/ui_qt/__init__.py
+++ b/app/ui_qt/__init__.py
@@ -1,0 +1,2 @@
+"""Qt-based user interface components for the EV simulation."""
+

--- a/app/ui_qt/qml/Main.qml
+++ b/app/ui_qt/qml/Main.qml
@@ -93,6 +93,7 @@ ApplicationWindow {
 
         Sidebar {
             id: sidebar
+            objectName: "sidebar"
             width: 320
             onSectionSelected: function(catIndex, sectionIndex) {
                 paramForm.currentSection = { category: catIndex, section: sectionIndex }
@@ -101,6 +102,7 @@ ApplicationWindow {
 
         ParamForm {
             id: paramForm
+            objectName: "paramForm"
             Layout.fillWidth: true
             query: sidebar.query
             showAdvanced: sidebar.showAdvancedChecked

--- a/app/ui_qt/qml/ParamForm.qml
+++ b/app/ui_qt/qml/ParamForm.qml
@@ -5,7 +5,7 @@ import QtQuick.Layouts
 Item {
     id: root
     property var currentSection: ({ category: 0, section: 0 })
-    property var categories: ParamCatalog.categories()
+    property var categories: ParamCatalog.categories
     property string query: ""
     property bool showAdvanced: false
 
@@ -53,6 +53,8 @@ Item {
                 width: parent.width
 
                 Repeater {
+                    id: fieldRepeater
+                    objectName: "fieldRepeater"
                     model: {
                         const section = safeSection(root.currentSection.category, root.currentSection.section)
                         return section ? section.fields || [] : []

--- a/app/ui_qt/qml/Sidebar.qml
+++ b/app/ui_qt/qml/Sidebar.qml
@@ -51,9 +51,10 @@ Item {
 
         ListView {
             id: catList
+            objectName: "categoryList"
             Layout.fillWidth: true
             Layout.fillHeight: true
-            model: ParamCatalog.categories()
+            model: ParamCatalog.categories
             clip: true
             delegate: Frame {
                 width: ListView.view.width

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for Python unit tests."""
+
+import pathlib
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+

--- a/tests/python/test_ui_elements.py
+++ b/tests/python/test_ui_elements.py
@@ -1,0 +1,86 @@
+"""Integration tests for the Qt Quick parameter UI."""
+
+import os
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtCore import QCoreApplication, QObject, QUrl  # noqa: E402  (import after skip)
+from PySide6.QtGui import QGuiApplication  # noqa: E402
+from PySide6.QtQml import QQmlApplicationEngine  # noqa: E402
+
+from app.main import Bridge, resource_path  # noqa: E402
+from app.model.param_catalog import ParamCatalog  # noqa: E402
+from app.model.param_store import ParamStore  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Provide a shared QApplication instance for Qt tests."""
+
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QGuiApplication.instance()
+    if app is None:
+        app = QGuiApplication([])
+    return app
+
+
+@pytest.fixture()
+def loaded_main(qapp):
+    """Load the main QML scene with the production context objects."""
+
+    catalog = ParamCatalog.from_json(resource_path("params/params_schema.json"))
+    store = ParamStore(catalog)
+    bridge = Bridge(store, catalog)
+
+    engine = QQmlApplicationEngine()
+    context = engine.rootContext()
+    context.setContextProperty("ParamCatalog", catalog)
+    context.setContextProperty("ParamStore", store)
+    context.setContextProperty("Bridge", bridge)
+
+    engine.load(QUrl.fromLocalFile(resource_path("ui_qt/qml/Main.qml")))
+    assert engine.rootObjects(), "Main QML failed to load"
+
+    QCoreApplication.processEvents()
+    root = engine.rootObjects()[0]
+
+    yield {
+        "root": root,
+        "engine": engine,
+        "catalog": catalog,
+        "store": store,
+        "bridge": bridge,
+    }
+
+    engine.deleteLater()
+    bridge.deleteLater()
+    store.deleteLater()
+    catalog.deleteLater()
+
+
+def test_sidebar_lists_categories(loaded_main):
+    """The sidebar should expose at least one category in the list view."""
+
+    root = loaded_main["root"]
+    sidebar = root.findChild(QObject, "sidebar")
+    assert sidebar is not None, "Sidebar component should be discoverable"
+
+    category_list = sidebar.findChild(QObject, "categoryList")
+    assert category_list is not None, "Sidebar should expose the category list view"
+    assert category_list.property("count") > 0
+
+
+def test_param_form_populates_fields(loaded_main):
+    """The parameter form should instantiate editors for the active section."""
+
+    root = loaded_main["root"]
+    param_form = root.findChild(QObject, "paramForm")
+    assert param_form is not None, "Parameter form should be discoverable"
+
+    repeater = param_form.findChild(QObject, "fieldRepeater")
+    assert repeater is not None, "Field repeater should exist in the parameter form"
+
+    QCoreApplication.processEvents()
+    assert repeater.property("count") > 0

--- a/tests/python/test_ui_elements.py
+++ b/tests/python/test_ui_elements.py
@@ -30,11 +30,13 @@ def qapp():
 def loaded_main(qapp):
     """Load the main QML scene with the production context objects."""
 
-    catalog = ParamCatalog.from_json(resource_path("params/params_schema.json"))
-    store = ParamStore(catalog)
-    bridge = Bridge(store, catalog)
-
     engine = QQmlApplicationEngine()
+    catalog = ParamCatalog.from_json(
+        resource_path("params/params_schema.json"), parent=engine
+    )
+    store = ParamStore(catalog, parent=engine)
+    bridge = Bridge(store, catalog)
+    bridge.setParent(engine)
     context = engine.rootContext()
     context.setContextProperty("ParamCatalog", catalog)
     context.setContextProperty("ParamStore", store)
@@ -55,9 +57,6 @@ def loaded_main(qapp):
     }
 
     engine.deleteLater()
-    bridge.deleteLater()
-    store.deleteLater()
-    catalog.deleteLater()
 
 
 def test_sidebar_lists_categories(loaded_main):


### PR DESCRIPTION
## Summary
- add a dedicated categories_schema helper so Python callers can access the parameter catalog safely
- tag key QML components with object names so tests can discover their UI controls
- introduce headless Qt integration tests that load the main view and assert sidebar/form population

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da4ba780e08333b3a633bf2042c3e4