### PR TITLE
Improve UI error handling and notifications

### DIFF
--- a/app/ui_qt/qml/Main.qml
+++ b/app/ui_qt/qml/Main.qml
@@ -111,6 +111,16 @@ ApplicationWindow {
 
     Toast { id: toast }
 
+    Connections {
+        target: Bridge
+        function onErrorOccurred(message) {
+            toast.showError(message)
+        }
+        function onInfoOccurred(message) {
+            toast.showInfo(message)
+        }
+    }
+
     FileDialog {
         id: importDialog
         title: qsTr("Import parameters (.json/.dat)")
@@ -132,7 +142,7 @@ ApplicationWindow {
             if (path.endsWith(".csv")) fmt = "csv"
             else if (path.endsWith(".dat")) fmt = "dat"
             win.exportRequested(path, fmt)
-            toast.show(qsTr("Parameters exported"))
+            toast.showSuccess(qsTr("Parameters exported"))
         }
     }
 
@@ -144,7 +154,7 @@ ApplicationWindow {
             const path = selectedFile
             let fmt = path.endsWith(".mf4") ? "mdf4" : "csv"
             Bridge.runSimulation(path, fmt)
-            toast.show(qsTr("Simulation started… results will be saved to: ") + path)
+            toast.showInfo(qsTr("Simulation started… results will be saved to: ") + path)
         }
     }
 }

--- a/app/ui_qt/qml/Toast.qml
+++ b/app/ui_qt/qml/Toast.qml
@@ -9,9 +9,14 @@ Popup {
     focus: false
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
+    property color infoColor: "#333333"
+    property color successColor: "#2e7d32"
+    property color errorColor: "#b00020"
+
     background: Rectangle {
+        id: backgroundRect
         radius: 8
-        color: "#333333"
+        color: popup.infoColor
         border.color: "#555555"
     }
 
@@ -22,10 +27,27 @@ Popup {
         wrapMode: Text.Wrap
     }
 
-    function show(msg) {
+    function showMessage(msg, color) {
         messageLabel.text = msg
+        backgroundRect.color = color
         open()
         hideTimer.restart()
+    }
+
+    function show(msg) {
+        showMessage(msg, popup.infoColor)
+    }
+
+    function showInfo(msg) {
+        showMessage(msg, popup.infoColor)
+    }
+
+    function showSuccess(msg) {
+        showMessage(msg, popup.successColor)
+    }
+
+    function showError(msg) {
+        showMessage(msg, popup.errorColor)
     }
 
     Timer {


### PR DESCRIPTION
## Summary
- emit structured success and error signals from the Python bridge so the UI can surface detailed feedback
- extend the Toast QML component with severity-specific helpers and wire it to bridge events for consistent messaging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da52a9c9a483339d6c81fb715c2401