### PR TITLE
Guard QML components when context properties are unavailable

### DIFF
--- a/app/ui_qt/qml/ParamForm.qml
+++ b/app/ui_qt/qml/ParamForm.qml
@@ -5,7 +5,8 @@ import QtQuick.Layouts
 Item {
     id: root
     property var currentSection: ({ category: 0, section: 0 })
-    property var categories: ParamCatalog.categories
+    readonly property var paramCatalog: (typeof ParamCatalog !== "undefined" && ParamCatalog !== null) ? ParamCatalog : null
+    property var categories: paramCatalog ? paramCatalog.categories : []
     property string query: ""
     property bool showAdvanced: false
 

--- a/app/ui_qt/qml/Sidebar.qml
+++ b/app/ui_qt/qml/Sidebar.qml
@@ -10,6 +10,7 @@ Item {
 
     property alias query: search.text
     property alias showAdvancedChecked: showAdvanced.checked
+    readonly property var paramCatalog: (typeof ParamCatalog !== "undefined" && ParamCatalog !== null) ? ParamCatalog : null
 
     Rectangle {
         anchors.fill: parent
@@ -54,7 +55,7 @@ Item {
             objectName: "categoryList"
             Layout.fillWidth: true
             Layout.fillHeight: true
-            model: ParamCatalog.categories
+            model: root.paramCatalog ? root.paramCatalog.categories : []
             clip: true
             delegate: Frame {
                 width: ListView.view.width


### PR DESCRIPTION
## Summary
- guard QML components against missing context properties so the UI can load without ParamCatalog/ParamStore
- add safe fallbacks for preset selection, parameter editors, and simulation trigger

## Testing
- pytest tests/python/test_ui_elements.py

------
https://chatgpt.com/codex/tasks/task_e_68da53eebd1483339c6c8dcc497d9242